### PR TITLE
Fixed permission setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,23 @@ RUN apk add --no-cache \
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 
 ### Add setup script to create persistent content
-COPY setup.sh /root/
+RUN mkdir -p /opt/nodepki
+COPY setup.sh /opt/nodepki/
 
-WORKDIR /root
+WORKDIR /opt/nodepki
 RUN curl -L https://github.com/aditosoftware/nodepki/archive/master.tar.gz | tar xz && mv nodepki-master nodepki \
 && curl -L https://github.com/aditosoftware/nodepki-client/archive/master.tar.gz | tar xz && mv nodepki-client-master nodepki-client \
 && curl -L https://github.com/aditosoftware/nodepki-webclient/archive/master.tar.gz | tar xz && mv nodepki-webclient-master nodepki-webclient \
-&& cd /root/nodepki-client \
+&& cd /opt/nodepki/nodepki-client \
 && npm install \
-&& cd /root/nodepki-webclient \
+&& cd /opt/nodepki/nodepki-webclient \
 && npm install \
-&& cd /root/nodepki \
+&& cd /opt/nodepki/nodepki \
 && npm install
+
+RUN adduser -D -g '' nodepki
+RUN chown -R nodepki:nodepki /opt/nodepki
+USER nodepki
 
 EXPOSE 8080 5000 2560
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NodePKI Docker Image
 
-```   
+```
 _   _           _      ____  _  _____
 | \ | | ___   __| | ___|  _ \| |/ /_ _|
 |  \| |/ _ \ / _` |/ _ \ |_) | ' / | |
@@ -48,7 +48,7 @@ variables in docker-compose.yml. A initial user account for API access will be c
 
 To create the persistent config files, run the following command:
 
-    sudo docker-compose run nodepki /bin/sh /root/setup.sh
+    sudo docker-compose run nodepki /bin/sh /opt/nodepki/setup.sh
 
 
 ## Configure NodePKI and NodePKI-Client
@@ -223,13 +223,13 @@ Ports:
 * 5000 (NodePKI Webclient - HTTP)
 
 Volumes:
-* data: Contains persistent container data (mounted to /root/nodepki/data/ and /root/nodepki-client/data/)
-* certs: Can be used to transfer and store cert files. (mounted to /root/nodepki-client/out/)
+* data: Contains persistent container data (mounted to /opt/nodepki/nodepki/data/ and /opt/nodepki/nodepki-client/data/)
+* certs: Can be used to transfer and store cert files. (mounted to /opt/nodepki/nodepki-client/out/)
 
 
 ## Add new API user
 
-    sudo docker-compose run nodepki node /root/nodepki/nodepkictl.js useradd --username user1 --password password
+    sudo docker-compose run nodepki node /opt/nodepki/nodepki/nodepkictl.js useradd --username user1 --password password
 
 
 ## CLI client Examples

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 ###  Set up NodePKI-Client
 echo ">>>>>> Setting up NodePKI-Client ..."
 
-cd /root/nodepki-client
+cd /opt/nodepki/nodepki-client
 mkdir data/config
 cp config.default.yml data/config/config.yml
 
@@ -12,7 +12,7 @@ sed -e "s/api_password/$API_PASSWORD/" data/config/config.yml > data/config/conf
 
 
 echo ">>>>>> Setting up NodePKI-Webclient ..."
-cd /root/nodepki-webclient
+cd /opt/nodepki/nodepki-webclient
 mkdir data/config
 cp config.default.yml data/config/config.yml
 
@@ -20,7 +20,7 @@ cp config.default.yml data/config/config.yml
 ### Set up NodePKI
 echo ">>>>>> Setting up NodePKI ..."
 
-cd /root/nodepki
+cd /opt/nodepki/nodepki
 mkdir data/config
 cp config.default.yml data/config/config.yml
 node nodepkictl useradd --username $API_USERNAME --password $API_PASSWORD

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,10 +1,11 @@
 [supervisord]
 nodaemon=true
+user = nodepki
 
 [program:nodepki]
-directory=/root/nodepki/
+directory=/opt/nodepki/nodepki/
 command=node server.js
 
 [program:nodepki_webclient]
-directory=/root/nodepki-webclient/
+directory=/opt/nodepki/nodepki-webclient/
 command=node app.js


### PR DESCRIPTION
Hi there,

The `nodepki` Docker image used user `root` to run the processes and inside `supervisord.conf` was no user specified which caused that some error messages where shown when starting the `nodepki` Docker container. It's not very secure to run processes inside Docker containers with the user `root` - that's also a reason why I created a new service user `nodepki` inside the `Dockerfile`.

The `CRIT` message `CRIT Set uid to user 1001` seems to should be only an `INFO` message: https://github.com/Supervisor/supervisor/issues/693.

Problem: 
```bash
macbookpro:nodepki phil$ docker-compose up
Starting nodepki_nodepki_1 ... done
Attaching to nodepki_nodepki_1
nodepki_1  | 2018-04-27 13:33:46,026 CRIT Supervisor running as root (no user in config file)
nodepki_1  | 2018-04-27 13:33:46,028 INFO supervisord started with pid 7
nodepki_1  | 2018-04-27 13:33:47,032 INFO spawned: 'nodepki' with pid 10
nodepki_1  | 2018-04-27 13:33:47,034 INFO spawned: 'nodepki_webclient' with pid 11
nodepki_1  | 2018-04-27 13:33:47,452 INFO exited: nodepki (exit status 1; not expected)
nodepki_1  | 2018-04-27 13:33:48,455 INFO spawned: 'nodepki' with pid 31
nodepki_1  | 2018-04-27 13:33:48,456 INFO success: nodepki_webclient entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
nodepki_1  | 2018-04-27 13:33:48,861 INFO exited: nodepki (exit status 1; not expected)
nodepki_1  | 2018-04-27 13:33:50,867 INFO spawned: 'nodepki' with pid 46
nodepki_1  | 2018-04-27 13:33:51,265 INFO exited: nodepki (exit status 1; not expected)
nodepki_1  | 2018-04-27 13:33:54,569 INFO spawned: 'nodepki' with pid 65
nodepki_1  | 2018-04-27 13:33:54,966 INFO exited: nodepki (exit status 1; not expected)
nodepki_1  | 2018-04-27 13:33:55,969 INFO gave up: nodepki entered FATAL state, too many start retries too quickly
```

After fix:
```bash
macbookpro:nodepki phil$ docker-compose up
Starting nodepki_nodepki_1 ... done
Attaching to nodepki_nodepki_1
nodepki_1  | 2018-04-27 14:01:27,002 CRIT Set uid to user 1001
nodepki_1  | 2018-04-27 14:01:27,005 INFO supervisord started with pid 7
nodepki_1  | 2018-04-27 14:01:28,367 INFO spawned: 'nodepki' with pid 10
nodepki_1  | 2018-04-27 14:01:28,370 INFO spawned: 'nodepki_webclient' with pid 11
nodepki_1  | 2018-04-27 14:01:29,766 INFO success: nodepki entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
nodepki_1  | 2018-04-27 14:01:29,766 INFO success: nodepki_webclient entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
```

Any feedback is welcome. Thanks.

Regards,
Philip